### PR TITLE
[TASK] Streamlining code-quality and prepare for PHP 8.4

### DIFF
--- a/Classes/Controller/JobController.php
+++ b/Classes/Controller/JobController.php
@@ -43,7 +43,7 @@ class JobController extends ActionController
         if ($job === null) {
             $this->addFlashMessage(
                 $this->translateAlert('job_not_found.body', 'Job not found.'),
-                null,
+                '',
                 FlashMessage::ERROR,
                 true
             );

--- a/Classes/Controller/JobController.php
+++ b/Classes/Controller/JobController.php
@@ -104,7 +104,7 @@ class JobController extends ActionController
         }
     }
 
-    public function newJobFormAction(Job $job = null): ResponseInterface
+    public function newJobFormAction(?Job $job = null): ResponseInterface
     {
         return $this->htmlResponse();
     }

--- a/Classes/Property/TypeConverter/JobAvatarImageUploadConverter.php
+++ b/Classes/Property/TypeConverter/JobAvatarImageUploadConverter.php
@@ -54,7 +54,7 @@ final class JobAvatarImageUploadConverter extends AbstractTypeConverter implemen
         $source,
         string $targetType,
         array $convertedChildProperties = [],
-        PropertyMappingConfigurationInterface $configuration = null
+        ?PropertyMappingConfigurationInterface $configuration = null
     ): Error|ExtbaseFileReference|null {
         $uploadedFileInformation = $source;
 

--- a/composer.json
+++ b/composer.json
@@ -87,9 +87,9 @@
 		}
 	},
 	"scripts": {
-		"cs:check": "php-cs-fixer fix --config Build/php-cs-fixer/php-cs-rules.php --ansi --diff --verbose --dry-run",
-		"cs:fix": "php-cs-fixer fix --config Build/php-cs-fixer/php-cs-rules.php --ansi",
-		"analyze:php": ".Build/bin/phpstan analyse --ansi --no-progress --memory-limit=768M --configuration=Build/phpstan/phpstan.neon",
-		"analyze:baseline": ".Build/bin/phpstan analyse --ansi --no-progress --memory-limit=768M --configuration=Build/phpstan/phpstan.neon --generate-baseline=Build/phpstan/phpstan-baseline.neon"
+		"cs:check": "@php .Build/bin/php-cs-fixer fix --config Build/php-cs-fixer/php-cs-rules.php --ansi --diff --verbose --dry-run",
+		"cs:fix": "@php .Build/bin/php-cs-fixer fix --config Build/php-cs-fixer/php-cs-rules.php --ansi",
+		"analyze:php": "@php .Build/bin/phpstan analyse --ansi --no-progress --memory-limit=768M --configuration=Build/phpstan/phpstan.neon",
+		"analyze:baseline": "@php .Build/bin/phpstan analyse --ansi --no-progress --memory-limit=768M --configuration=Build/phpstan/phpstan.neon --generate-baseline=Build/phpstan/phpstan-baseline.neon"
 	}
 }


### PR DESCRIPTION
- **[TASK] Use same php version for composer scripts**
  Using `@php` within composer scripts to call other
  php scripts or binaries is a casual way to ensure
  that child execution uses the same version of PHP
  used to call composer already and mitiage issues
  on systems providing multiple suffixed php versions.
  

- **[TASK] Pass correct parameter type to TYPO3 API in `JobController`**
  PHPStan reports invalid passed type for a method based
  on PHP-DocBlock annotation and gladly no native types
  are in place from TYPO3 in current version.
  
  This change adjusts calling code place to pass compatible
  method argument type and prepare for TYPO3 upgrades and
  mitigates following PHPStan error:
  
  ```
  Parameter #2 $messageTitle of method
  TYPO3\CMS\Extbase\Mvc\Controller\ActionController::addFlashMessage()
  expects string, null given.
  ```
  

- **[TASK] Mitigate implicitly nullable parameter declarations**
  Since PHP 8.4 implicitly nullable parameter declartions are
  deprecated and emitting `E_DEPRECATED` notices.
  
  The recommended way to mitigate these places depends on the
  current place, but the spotted places within this extension
  can be mitigated by simply changing directly to a nullable
  type declaration and considerable non-breaking in this case.
  
  [1] https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated
  