### PR TITLE
[TASK] Streamlining code-quality, tooling and prepare for PHP 8.4

### DIFF
--- a/.github/workflows/testcore11.yml
+++ b/.github/workflows/testcore11.yml
@@ -15,6 +15,13 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v3
 
+      - name: "Link docker compose"
+        run: |
+          echo "#!/usr/bin/env bash" > /usr/local/bin/docker-compose
+          echo "" >> /usr/local/bin/docker-compose
+          echo "docker compose \"\$@\"" >> /usr/local/bin/docker-compose
+          chmod a+x /usr/local/bin/docker-compose
+
       - name: "Prepare dependencies for TYPO3 v11"
         run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s composerUpdate"
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 /.php-cs-fixer.cache
 /composer.lock
+/composer.json.*
 
 /Documentation-GENERATED-temp
 

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -105,12 +105,12 @@ Options:
             - mysql: use mysql
             - postgres: use postgres
 
-    -p <7.4|8.0|8.1|8.2>
+    -p <8.1|8.2|8.3|8.4>
         Specifies the PHP minor version to be used
-            - 7.4 (default): use PHP 7.4
-            - 8.0: use PHP 8.0
-            - 8.1: use PHP 8.1
+            - 8.1: use PHP 8.1 (default)
             - 8.2: use PHP 8.2
+            - 8.3: use PHP 8.3
+            - 8.4: use PHP 8.4
 
     -t <11|12>
         Only with -s composerUpdate
@@ -191,7 +191,7 @@ else
 fi
 TEST_SUITE=""
 DBMS="sqlite"
-PHP_VERSION="7.4"
+PHP_VERSION="8.1"
 TYPO3_VERSION="11"
 PHP_XDEBUG_ON=0
 EXTRA_TEST_OPTIONS=""
@@ -219,7 +219,7 @@ while getopts ":s:a:d:p:t:e:xnhuv" OPT; do
             ;;
         p)
             PHP_VERSION=${OPTARG}
-            if ! [[ ${PHP_VERSION} =~ ^(7.4|8.0|8.1|8.2)$ ]]; then
+            if ! [[ ${PHP_VERSION} =~ ^(8.1|8.2|8.3|8.4)$ ]]; then
                 INVALID_OPTIONS+=("p ${OPTARG}")
             fi
             ;;

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -450,7 +450,7 @@ services:
         fi
         mkdir -p .Build/.cache
         php -v | grep '^PHP';
-        php -dxdebug.mode=off .Build/bin/phpstan analyze -c Build/phpstan/Core${TYPO3_VERSION}/phpstan.neon --no-progress
+        php -dxdebug.mode=off .Build/bin/phpstan analyze -c Build/phpstan/phpstan.neon --no-progress
       "
 
   phpstan_generate_baseline:
@@ -466,7 +466,7 @@ services:
         fi
         mkdir -p .Build/.cache
         php -v | grep '^PHP';
-        php -dxdebug.mode=off .Build/bin/phpstan analyze -c Build/phpstan/Core${TYPO3_VERSION}/phpstan.neon --generate-baseline=Build/phpstan/Core${TYPO3_VERSION}/phpstan-baseline.neon
+        php -dxdebug.mode=off .Build/bin/phpstan analyze -c Build/phpstan/phpstan.neon --generate-baseline=Build/phpstan/phpstan-baseline.neon
       "
 
   unit:

--- a/Classes/Controller/JobController.php
+++ b/Classes/Controller/JobController.php
@@ -43,7 +43,7 @@ class JobController extends ActionController
         if ($job === null) {
             $this->addFlashMessage(
                 $this->translateAlert('job_not_found.body', 'Job not found.'),
-                null,
+                '',
                 FlashMessage::ERROR,
                 true
             );

--- a/Classes/Controller/JobController.php
+++ b/Classes/Controller/JobController.php
@@ -104,7 +104,7 @@ class JobController extends ActionController
         }
     }
 
-    public function newJobFormAction(Job $job = null): ResponseInterface
+    public function newJobFormAction(?Job $job = null): ResponseInterface
     {
         return $this->htmlResponse();
     }

--- a/Classes/Property/TypeConverter/JobAvatarImageUploadConverter.php
+++ b/Classes/Property/TypeConverter/JobAvatarImageUploadConverter.php
@@ -54,7 +54,7 @@ final class JobAvatarImageUploadConverter extends AbstractTypeConverter implemen
         $source,
         string $targetType,
         array $convertedChildProperties = [],
-        PropertyMappingConfigurationInterface $configuration = null
+        ?PropertyMappingConfigurationInterface $configuration = null
     ): Error|ExtbaseFileReference|null {
         $uploadedFileInformation = $source;
 

--- a/composer.json
+++ b/composer.json
@@ -87,9 +87,9 @@
 		}
 	},
 	"scripts": {
-		"cs:check": "php-cs-fixer fix --config Build/php-cs-fixer/php-cs-rules.php --ansi --diff --verbose --dry-run",
-		"cs:fix": "php-cs-fixer fix --config Build/php-cs-fixer/php-cs-rules.php --ansi",
-		"analyze:php": ".Build/bin/phpstan analyse --ansi --no-progress --memory-limit=768M --configuration=Build/phpstan/phpstan.neon",
-		"analyze:baseline": ".Build/bin/phpstan analyse --ansi --no-progress --memory-limit=768M --configuration=Build/phpstan/phpstan.neon --generate-baseline=Build/phpstan/phpstan-baseline.neon"
+		"cs:check": "@php .Build/bin/php-cs-fixer fix --config Build/php-cs-fixer/php-cs-rules.php --ansi --diff --verbose --dry-run",
+		"cs:fix": "@php .Build/bin/php-cs-fixer fix --config Build/php-cs-fixer/php-cs-rules.php --ansi",
+		"analyze:php": "@php .Build/bin/phpstan analyse --ansi --no-progress --memory-limit=768M --configuration=Build/phpstan/phpstan.neon",
+		"analyze:baseline": "@php .Build/bin/phpstan analyse --ansi --no-progress --memory-limit=768M --configuration=Build/phpstan/phpstan.neon --generate-baseline=Build/phpstan/phpstan-baseline.neon"
 	}
 }


### PR DESCRIPTION
- **[TASK] Streamline `Build/Scripts/runTests.sh`**
  The `Build/Scripts/runTests.sh` dispatch wrapper
  has been shifted away from the reality for this
  extension and **must** be aligned, alone due to
  the fact that it is used within the GitHub CI/CD
  pipelines.
  
  Note that it is really bad practice not covering
  all PHP versions supported by the supported TYPO3
  version, but not revertable `yet`. In the future
  this should be respected for newer versions. This
  is not company project and published for the wild.
  
  * Remove PHP 7.4 and 8.0 support, not allowing to
    select them and use `PHP 8.1` as new default.
  * Add `composer.json.*` pattern to `.gitignore`,
    used by `Build/Scripts/runTests.sh` to backup
    it during `-s composerUpdate`.
  * GitHub images no longer provides the standalone
    `docker-compose` command in favour of the newer
    `docker compose` plugin. It's not reasonable to
    rework the `runTests.sh` script for now to deal
    with both variants and dropped at all, GitHub
    action workflow gets a new step to provide a
    intermedia solution to allow executing the other
    steps again.
  * Use correct phpstan configuration and baseline
    file paths in deprecated `docker-compose.yml`.
  
  In general `Build/Scripts/runTests.sh` should be
  streamlined to the newer TYPO3 variant avoiding
  `docker-compose` at all.
  

- **[TASK] Use same php version for composer scripts**
  Using `@php` within composer scripts to call other
  php scripts or binaries is a casual way to ensure
  that child execution uses the same version of PHP
  used to call composer already and mitiage issues
  on systems providing multiple suffixed php versions.
  

- **[TASK] Pass correct parameter type to TYPO3 API in `JobController`**
  PHPStan reports invalid passed type for a method based
  on PHP-DocBlock annotation and gladly no native types
  are in place from TYPO3 in current version.
  
  This change adjusts calling code place to pass compatible
  method argument type and prepare for TYPO3 upgrades and
  mitigates following PHPStan error:
  
  ```
  Parameter #2 $messageTitle of method
  TYPO3\CMS\Extbase\Mvc\Controller\ActionController::addFlashMessage()
  expects string, null given.
  ```
  

- **[TASK] Mitigate implicitly nullable parameter declarations**
  Since PHP 8.4 implicitly nullable parameter declartions are
  deprecated and emitting `E_DEPRECATED` notices.
  
  The recommended way to mitigate these places depends on the
  current place, but the spotted places within this extension
  can be mitigated by simply changing directly to a nullable
  type declaration and considerable non-breaking in this case.
  
  [1] https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated
  