### PR TITLE
[FEATURE] Add dedicated redirect page configuration for `NewJobForm`

### DIFF
--- a/Classes/Event/AfterSaveJobEvent.php
+++ b/Classes/Event/AfterSaveJobEvent.php
@@ -5,18 +5,61 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicJobs\Event;
 
 use FGTCLB\AcademicJobs\Domain\Model\Job;
+use Psr\Http\Message\ServerRequestInterface;
 
 final class AfterSaveJobEvent
 {
-    private Job $job;
-
-    public function __construct(Job $job)
-    {
-        $this->job = $job;
+    /**
+     * @param array<string, mixed> $settings
+     */
+    public function __construct(
+        private readonly ServerRequestInterface $request,
+        private Job $job,
+        private readonly array $settings,
+        private ?int $redirectPageId,
+    ) {
     }
 
     public function getJob(): Job
     {
         return $this->job;
+    }
+
+    public function getRequest(): ServerRequestInterface
+    {
+        return $this->request;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getSettings(): array
+    {
+        return $this->settings;
+    }
+
+    /**
+     * Get page to redirect after persisting new job. NULL redirects to the same page (new form).
+     *
+     * Currently, global TypoScript `listPid` setting is used as last fallback to redirect after
+     * successfully persisting a new job, which is deprecated and will be removed in the future.
+     *
+     * @return int|null
+     */
+    public function getRedirectPageId(): ?int
+    {
+        return $this->redirectPageId;
+    }
+
+    /**
+     * Set page to redirect after persisting new job. NULL redirects to the same page (new form).
+     *
+     * Currently, global TypoScript `listPid` setting is used as last fallback to redirect after
+     * successfully persisting a new job, which is deprecated and will be removed in the future.
+     */
+    public function setRedirectPageId(?int $redirectPageId): self
+    {
+        $this->redirectPageId = $redirectPageId;
+        return $this;
     }
 }

--- a/Configuration/Flexforms/PluginList.xml
+++ b/Configuration/Flexforms/PluginList.xml
@@ -3,19 +3,19 @@
         <sDEF>
             <ROOT>
                 <TCEforms>
-                    <sheetTitle>Settings</sheetTitle>
+                    <sheetTitle>LLL:EXT:academic_jobs/Resources/Private/Language/locallang.xlf:tx_academicjobs_domain_model_job.pi_flexform.sheetGeneral</sheetTitle>
                 </TCEforms>
                 <type>array</type>
                 <el>
                     <settings.job.type>
                         <TCEforms>
-                            <label>Job Type</label>
+                            <label>LLL:EXT:academic_jobs/Resources/Private/Language/locallang.xlf:tx_academicjobs_domain_model_job.list.jobType.label</label>
                             <config>
                                 <type>select</type>
                                 <renderType>selectSingle</renderType>
                                 <items>
                                     <numIndex index="0" type="array">
-                                        <numIndex index="0">None</numIndex>
+                                        <numIndex index="0">LLL:EXT:academic_jobs/Resources/Private/Language/locallang.xlf:tx_academicjobs_domain_model_job.jobtype.none</numIndex>
                                         <numIndex index="1">0</numIndex>
                                     </numIndex>
                                     <numIndex index="1" type="array">

--- a/Configuration/Flexforms/Plugin_NewJobForm.xml
+++ b/Configuration/Flexforms/Plugin_NewJobForm.xml
@@ -1,0 +1,31 @@
+<T3DataStructure>
+    <sheets>
+        <sDEF>
+            <ROOT>
+                <TCEforms>
+                    <sheetTitle>LLL:EXT:academic_jobs/Resources/Private/Language/locallang.xlf:tx_academicjobs_domain_model_job.pi_flexform.sheetGeneral</sheetTitle>
+                </TCEforms>
+                <type>array</type>
+                <el>
+                    <settings.redirectPageId>
+                        <TCEforms>
+                            <label>LLL:EXT:academic_jobs/Resources/Private/Language/locallang.xlf:tx_academicjobs_domain_model_job.newJobForm.redirectPageId.label</label>
+                            <config>
+                                <type>group</type>
+                                <allowed>pages</allowed>
+                                <maxitems>1</maxitems>
+                                <minitems>0</minitems>
+                                <size>1</size>
+                                <suggestOptions>
+                                    <default>
+                                        <additionalSearchFields>title, nav_title, alias, url</additionalSearchFields>
+                                    </default>
+                                </suggestOptions>
+                            </config>
+                        </TCEforms>
+                    </settings.redirectPageId>
+                </el>
+            </ROOT>
+        </sDEF>
+    </sheets>
+</T3DataStructure>

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -28,9 +28,14 @@ if (!defined('TYPO3')) {
     $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['academicjobs_list'] = 'pages,layout,select_key,recursive';
 
     $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['academicjobs_list'] = 'pi_flexform';
+    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['academicjobs_newjobform'] = 'pi_flexform';
 
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
         'academicjobs_list',
         'FILE:EXT:academic_jobs/Configuration/Flexforms/PluginList.xml'
+    );
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
+        'academicjobs_newjobform',
+        'FILE:EXT:academic_jobs/Configuration/Flexforms/Plugin_NewJobForm.xml'
     );
 })();

--- a/Configuration/TypoScript/constants.typoscript
+++ b/Configuration/TypoScript/constants.typoscript
@@ -24,4 +24,9 @@ plugin.tx_academicjobs {
         subject = New job application
         template = A new job application has been submitted. Please check the backend.
     }
+
+    saveForm {
+        # cat=plugin.tx_academicjobs_createjob//a; type=string; label=Default redirect page PID, can be overruled in plugin
+        fallbackRedirectPageId =
+    }
 }

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -38,6 +38,7 @@ plugin.tx_academicjobs {
           allowedMimeTypes = image/jpeg,image/png,image/webp,image/svg+xml
         }
       }
+      fallbackRedirectPageId = {$plugin.tx_academicjobs.saveForm.fallbackRedirectPageId}
     }
   }
   view {

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -3,6 +3,24 @@
 	<file source-language="en" target-langague="de" datatype="plaintext" original="EXT:academic_jobs/Resources/Private/Language/locallang.xlf" date="2023-09-02T12:17:09Z" product-name="academic_jobs">
 		<header/>
 		<body>
+            <!-- Flexform General -->
+            <trans-unit id="tx_academicjobs_domain_model_job.pi_flexform.sheetGeneral">
+                <source>Settings</source>
+                <target>Settings</target>
+            </trans-unit>
+
+            <!-- Flexform Plugin List -->
+            <trans-unit id="tx_academicjobs_domain_model_job.list.jobType.label">
+                <source>Job Type</source>
+                <target>Job Type</target>
+            </trans-unit>
+
+            <!-- Flexform Plugin NewJobForm -->
+            <trans-unit id="tx_academicjobs_domain_model_job.newJobForm.redirectPageId.label">
+                <source>Redirect page after job creation</source>
+                <target>Weiterleitungsseite nach erfolgreichen anlegen eines Jobs</target>
+            </trans-unit>
+
 			<!-- Domain Model: Job -->
 
 			<trans-unit id="tx_academicjobs_domain_model_job">
@@ -137,6 +155,10 @@
 				<source>Contact</source>
 				<target>Kontakt</target>
 			</trans-unit>
+            <trans-unit id="tx_academicjobs_domain_model_job.jobtype.none">
+                <source>None</source>
+                <target>Keine Auswahl</target>
+            </trans-unit>
 			<trans-unit id="tx_academicjobs_domain_model_job.jobtype.job">
 				<source>Job</source>
 				<target>Job</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -3,6 +3,21 @@
 	<file source-language="en" datatype="plaintext" original="EXT:academic_jobs/Resources/Private/Language/locallang.xlf" date="2023-09-02T12:17:09Z" product-name="academic_jobs">
 		<header/>
 		<body>
+            <!-- Flexform General -->
+            <trans-unit id="tx_academicjobs_domain_model_job.pi_flexform.sheetGeneral">
+                <source>Settings</source>
+            </trans-unit>
+
+            <!-- Flexform Plugin List -->
+            <trans-unit id="tx_academicjobs_domain_model_job.list.jobType.label">
+                <source>Job Type</source>
+            </trans-unit>
+
+            <!-- Flexform Plugin NewJobForm -->
+            <trans-unit id="tx_academicjobs_domain_model_job.newJobForm.redirectPageId.label">
+                <source>Redirect page after job creation</source>
+            </trans-unit>
+
 			<!-- Domain Model: Job -->
 
 			<trans-unit id="tx_academicjobs_domain_model_job">
@@ -104,6 +119,9 @@
 			<trans-unit id="tx_academicjobs_domain_model_job.contact.description">
 				<source>Contact</source>
 			</trans-unit>
+            <trans-unit id="tx_academicjobs_domain_model_job.jobtype.none">
+                <source>None</source>
+            </trans-unit>
 			<trans-unit id="tx_academicjobs_domain_model_job.jobtype.job">
 				<source>Job</source>
 			</trans-unit>


### PR DESCRIPTION
Processing new job form transfers used the global extension setting
`listPid` to determine the action to take after successfully persist
a new job entry.

Until now, no flash messages are created and redirected to selected
`listPid`, otherwse flashmessage are created and redirected to the
newJobForm page and form display action.

Using the global `listPid` option is not really reasonable for this,
as projects may want to redirect to a dedicated page after persisting
new jobs which are not the `listPid` page. That means, this option
could not be used or reconfigured as it would break the `listPid`
based back link display within the detail plugin/action.

To dismantel the missuse of `listPid` a new configiguration is now
added in a defined multistep fallback layer:

*  NewJobForm flexform option `redirectPageId`: This option has the
   highest priority from all pure configuration based options.

   ![image](https://github.com/user-attachments/assets/04f4b92e-56d3-4636-8ea8-d8ea94a54d85)

*  `plugin.tx_academicjobs.settings.saveForm.fallbackRedirectPageId`
   as fallback when plugin settings is not set.

   ![image](https://github.com/user-attachments/assets/5405bfb2-5aad-4b54-ba72-6d9ff475f36b)
 
*  (Deprecated) Last fallback is to use the global `listPid` setting,
   which is deprecated and will be removed in upcoming versions.

Already existing `AfterSaveJobEvent` is extended:

* `getRequest()` recieving current request
* `getSettings()` to get current determined flexform and TypoScript
  settings.
* `getRedirectPageId(): ?int`: Current set page id to redirect,
  not reflecting deprecated listPid fallback.
* `setRedirectPageId(?int): self`: Can be used to set or remove
  the redirect page. Note, setting this to null will fallback
  to deprecated listPid redirect.

Deprecated listPid fallback usage will emit a `E_USER_DEPRECATED`
error and silently stop working in a upcoming version.

Risk assesment for this change can be defined as non-existing,
because the whole change is implemented in breaking-free manner.
