### PR TITLE
[FEATURE] Add configurable FlashMessage creation mode

### DIFF
--- a/Classes/Event/AfterSaveJobEvent.php
+++ b/Classes/Event/AfterSaveJobEvent.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicJobs\Event;
 
 use FGTCLB\AcademicJobs\Domain\Model\Job;
+use FGTCLB\AcademicJobs\SaveForm\FlashMessageCreationMode;
 use Psr\Http\Message\ServerRequestInterface;
 
 final class AfterSaveJobEvent
@@ -14,8 +15,10 @@ final class AfterSaveJobEvent
      */
     public function __construct(
         private readonly ServerRequestInterface $request,
-        private Job $job,
+        private readonly Job $job,
+        private readonly int $currentPageId,
         private readonly array $settings,
+        private FlashMessageCreationMode $flashMessageCreationMode,
         private ?int $redirectPageId,
     ) {
     }
@@ -28,6 +31,11 @@ final class AfterSaveJobEvent
     public function getRequest(): ServerRequestInterface
     {
         return $this->request;
+    }
+
+    public function getCurrentPageId(): int
+    {
+        return $this->currentPageId;
     }
 
     /**
@@ -60,6 +68,17 @@ final class AfterSaveJobEvent
     public function setRedirectPageId(?int $redirectPageId): self
     {
         $this->redirectPageId = $redirectPageId;
+        return $this;
+    }
+
+    public function getFlashMessageCreationMode(): FlashMessageCreationMode
+    {
+        return $this->flashMessageCreationMode;
+    }
+
+    public function setFlashMessageCreationMode(FlashMessageCreationMode $flashMessageCreationMode): AfterSaveJobEvent
+    {
+        $this->flashMessageCreationMode = $flashMessageCreationMode;
         return $this;
     }
 }

--- a/Classes/SaveForm/FlashMessageCreationMode.php
+++ b/Classes/SaveForm/FlashMessageCreationMode.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicJobs\SaveForm;
+
+enum FlashMessageCreationMode: int
+{
+    case SUPPRESS_WITH_CONFIGURED_REDIRECT_PAGE = 0;
+    case ALWAYS = 1;
+    case NEVER = 2;
+
+    public static function default(): self
+    {
+        return self::SUPPRESS_WITH_CONFIGURED_REDIRECT_PAGE;
+    }
+
+    /**
+     * - self::ALWAYS returns true
+     * - self::NEVER returns false
+     * - self::SUPPRESS_WITH_CONFIGURED_REDIRECT_PAGE returns true redirectPage is not set or the current page,
+     *   otherwise false is returned (to suppress creation of FlashMessages)
+     */
+    public function shouldBeCreated(int $currentPageId, ?int $redirectPageId = null): bool
+    {
+        $shouldRedirect = ($redirectPageId !== null && $redirectPageId > 0 && $currentPageId !== $redirectPageId);
+        return match($this) {
+            self::ALWAYS => true,
+            self::NEVER => false,
+            self::SUPPRESS_WITH_CONFIGURED_REDIRECT_PAGE => $shouldRedirect === false,
+        };
+    }
+}

--- a/Configuration/Flexforms/Plugin_NewJobForm.xml
+++ b/Configuration/Flexforms/Plugin_NewJobForm.xml
@@ -24,6 +24,38 @@
                             </config>
                         </TCEforms>
                     </settings.redirectPageId>
+                    <settings.flashMessageCreationMode>
+                        <TCEforms>
+                            <label>LLL:EXT:academic_jobs/Resources/Private/Language/locallang.xlf:saveForm.flashMessageCreationMode.label</label>
+                            <config>
+                                <type>select</type>
+                                <renderType>selectSingle</renderType>
+                                <default>-1</default>
+                                <items>
+                                    <!-- /* TYPO3 v11 Syntax, compatible with TYPO3 v12. Needs to be changed when TYPO3 v13 */ -->
+                                    <!-- /* support is added and should be done with dropping TYPO3 v11 support in same run.  */ -->
+                                    <!-- /* @todo Adjust syntax using <label></lable>, <value></value> instead of element numIndex */ -->
+                                    <!-- /* @todo to align with TCA Select changes */ -->
+                                    <numIndex index="0">
+                                        <numIndex index="0">LLL:EXT:academic_jobs/Resources/Private/Language/locallang.xlf:saveForm.flashMessageCreationMode.use_global_setting</numIndex>>
+                                        <numIndex index="1">-1</numIndex>>
+                                    </numIndex>
+                                    <numIndex index="1">
+                                        <numIndex index="0">LLL:EXT:academic_jobs/Resources/Private/Language/locallang.xlf:saveForm.flashMessageCreationMode.option_always</numIndex>
+                                        <numIndex index="1">1</numIndex>>
+                                    </numIndex>
+                                    <numIndex index="2">
+                                        <numIndex index="0">LLL:EXT:academic_jobs/Resources/Private/Language/locallang.xlf:saveForm.flashMessageCreationMode.option_never</numIndex>>
+                                        <numIndex index="1">2</numIndex>>
+                                    </numIndex>
+                                    <numIndex index="3">
+                                        <numIndex index="0">LLL:EXT:academic_jobs/Resources/Private/Language/locallang.xlf:saveForm.flashMessageCreationMode.option_suppressWhenRedirectPageIsSelected</numIndex>
+                                        <numIndex index="1">0</numIndex>
+                                    </numIndex>
+                                </items>
+                            </config>
+                        </TCEforms>
+                    </settings.flashMessageCreationMode>
                 </el>
             </ROOT>
         </sDEF>

--- a/Configuration/TypoScript/constants.typoscript
+++ b/Configuration/TypoScript/constants.typoscript
@@ -28,5 +28,7 @@ plugin.tx_academicjobs {
     saveForm {
         # cat=plugin.tx_academicjobs_createjob//a; type=string; label=Default redirect page PID, can be overruled in plugin
         fallbackRedirectPageId =
+        # cat=plugin.tx_academicjobs_createjob//a; type=options [LLL:EXT:academic_jobs/Resources/Private/Language/locallang.xlf:saveForm.flashMessageCreationMode.option_always=1,LLL:EXT:academic_jobs/Resources/Private/Language/locallang.xlf:saveForm.flashMessageCreationMode.option_suppressWhenRedirectPageIsSelected=0,LLL:EXT:academic_jobs/Resources/Private/Language/locallang.xlf:saveForm.flashMessageCreationMode.option_never=2]; label=LLL:EXT:academic_jobs/Resources/Private/Language/locallang.xlf:saveForm.flashMessageCreationMode.label
+        fallbackFlashMessageCreationMode = 0
     }
 }

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -39,6 +39,7 @@ plugin.tx_academicjobs {
         }
       }
       fallbackRedirectPageId = {$plugin.tx_academicjobs.saveForm.fallbackRedirectPageId}
+      fallbackFlashMessageCreationMode = {$plugin.tx_academicjobs.saveForm.fallbackFlashMessageCreationMode}
     }
   }
   view {

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -3,6 +3,7 @@
 	<file source-language="en" target-langague="de" datatype="plaintext" original="EXT:academic_jobs/Resources/Private/Language/locallang.xlf" date="2023-09-02T12:17:09Z" product-name="academic_jobs">
 		<header/>
 		<body>
+
             <!-- Flexform General -->
             <trans-unit id="tx_academicjobs_domain_model_job.pi_flexform.sheetGeneral">
                 <source>Settings</source>
@@ -19,6 +20,25 @@
             <trans-unit id="tx_academicjobs_domain_model_job.newJobForm.redirectPageId.label">
                 <source>Redirect page after job creation</source>
                 <target>Weiterleitungsseite nach erfolgreichen anlegen eines Jobs</target>
+            </trans-unit>
+
+            <!-- Backend: TypoScript Constants Editor -->
+
+            <trans-unit id="saveForm.flashMessageCreationMode.label">
+                <source>Flashmessage creation mode when persisting new jobs (FE)</source>
+                <target>Flashmessage creation mode when persisting new jobs (FE)</target>
+            </trans-unit>
+            <trans-unit id="saveForm.flashMessageCreationMode.option_always">
+                <source>always</source>
+                <target>immer</target>
+            </trans-unit>
+            <trans-unit id="saveForm.flashMessageCreationMode.option_never">
+                <source>never</source>
+                <target>niemals</target>
+            </trans-unit>
+            <trans-unit id="saveForm.flashMessageCreationMode.option_suppressWhenListPidSelected">
+                <source>suppress when list pid has been configured</source>
+                <target>Nur wenn keine listPid gesetzt wurde.</target>
             </trans-unit>
 
 			<!-- Domain Model: Job -->

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -18,6 +18,28 @@
                 <source>Redirect page after job creation</source>
             </trans-unit>
 
+            <trans-unit id="tx_academicjobs_domain_model_job.newJobForm.flashMessageCreationMode.label">
+                <source>Create FlashMessage</source>
+            </trans-unit>
+
+            <!-- Backend: TypoScript Constants Editor -->
+
+            <trans-unit id="saveForm.flashMessageCreationMode.label">
+                <source>Flashmessage creation mode when persisting new jobs (FE)</source>
+            </trans-unit>
+            <trans-unit id="saveForm.flashMessageCreationMode.use_global_setting">
+                <source>Fallback - Use TypoScript settings</source>
+            </trans-unit>
+            <trans-unit id="saveForm.flashMessageCreationMode.option_always">
+                <source>always</source>
+            </trans-unit>
+            <trans-unit id="saveForm.flashMessageCreationMode.option_never">
+                <source>never</source>
+            </trans-unit>
+            <trans-unit id="saveForm.flashMessageCreationMode.option_suppressWhenRedirectPageIsSelected">
+                <source>suppress when list pid has been configured</source>
+            </trans-unit>
+
 			<!-- Domain Model: Job -->
 
 			<trans-unit id="tx_academicjobs_domain_model_job">


### PR DESCRIPTION
Until now, flash message to communicate notification
has only been created when not redirecting to the
configured `listPid`, which has already been replaced
with redirecting based on a dedicated `redirectPageId`
configuration.

In the one or other project it may be still reasonable
to display the notification even when redirecting to
another page. This requires to take care to really
consume the extbase flashmessage queue, but is doable
with casual integration tools and not part of this
change but adding a dedicated `display messages` plugin
is planned to be added as a followup to ship at least
a working default.

This change introduces configurable FlashMessage creation
mode in three levels:

*  Plugin `NewJobForm` flexform setting
   ![image](https://github.com/user-attachments/assets/ea674af8-9500-4d75-906b-ed767384738b)

*  Fallback to TypoScript SETUP/CONSTANT setting,
   when the default `Use TypoScript` setting is
   configured in plugin flexform settings.
   ![image](https://github.com/user-attachments/assets/e2f0f512-c488-4817-a889-f8ffffa2c45c)

*  Pass flash message creation mode enum as part
   of the `AfterSaveJobEvent` to provide a way
   for deveopers to implement programatically
   way in projects to determine the setting as
   last resort.

On the PHP side the options are implemented as
PHP integer baked enum, which is possible due
to having PHP 8.1 as minimal PHP version set,
beside not beeing a good move but avoids the
need to use old-school constants here for now.

Following modes are possible:

* `FlashMessageCreationMode::SUPPRESS_WITH_CONFIGURED_REDIRECT_PAGE`
   (INT: 0) which is the default and matches the current
   existing behaviour to create flash messages only when
   redirecting to the new form page again.
*  `FlashMessageCreationMode::ALWAYS` (INT: 1) always create
   flash messages, even when redirecting to another page,
   which require to take care that flashmessages are really
   consumed. Dedicated consuming plugin will be added with
   a follow-up feature, but can be done with casual TYPO3
   integration patterns already.

Risk assesment is considerable `no risk` as the default
fallback reflects the current state to suppress flash
messages when redirecting to another page and no action
needed directly to change anything in projects.

That means that this feature is non-breaking and has
absolutly no impact in existing installation, until
configuration options are used to change the creation
behaviour.

```xml
<f:flashMessages
  queueIdentifier="extbase.flashmessages.tx_academicjobs_newjobform"
/>
```

In general, this change on itself is not complete on
it's own, which is a known fact and will be handled.
